### PR TITLE
refactor: prepared queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,7 @@ dependencies = [
  "once_cell",
  "scylla",
  "scyllax-macros",
+ "scyllax-macros-core",
  "thiserror",
  "tracing",
  "uuid",
@@ -918,6 +919,13 @@ dependencies = [
 
 [[package]]
 name = "scyllax-macros"
+version = "0.1.4-alpha"
+dependencies = [
+ "scyllax-macros-core",
+]
+
+[[package]]
+name = "scyllax-macros-core"
 version = "0.1.4-alpha"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["example", "scyllax-macros"]
+members = ["example", "scyllax-macros", "scyllax-macros-core"]
 resolver = "2"
 
 [workspace.package]
@@ -34,6 +34,7 @@ mac_address = "1"
 once_cell = "1"
 scylla = { workspace = true }
 scyllax-macros = { version = "0.1.4-alpha", path = "./scyllax-macros" }
+scyllax-macros-core = { version = "0.1.4-alpha", path = "./scyllax-macros-core" }
 thiserror = "1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/example/expanded.rs
+++ b/example/expanded.rs
@@ -1,2233 +1,1170 @@
-pub mod person {
-    //! The Person entity
-    /// The model itself
-    pub mod model {
-        use scyllax::prelude::*;
-        /// Represents data from a person
-        pub struct PersonData {
-            /// The stripe id of the person
-            #[serde(rename = "stripeId")]
-            pub stripe_id: Option<String>,
-        }
-        #[automatically_derived]
-        impl ::core::clone::Clone for PersonData {
-            #[inline]
-            fn clone(&self) -> PersonData {
-                PersonData {
-                    stripe_id: ::core::clone::Clone::clone(&self.stripe_id),
+/// All select queries
+pub mod queries {
+    use scyllax::PreparedStatement;
+    #[allow(non_snake_case)]
+    use scyllax::{delete_query, prelude::*};
+    use uuid::Uuid;
+    ///A collection of prepared statements.
+    #[allow(non_snake_case)]
+    pub struct PersonEntityQueries {
+        #[allow(non_snake_case)]
+        ///The prepared statement for `GetPersonById`.
+        pub GetPersonById: scylla::statement::prepared_statement::PreparedStatement,
+        #[allow(non_snake_case)]
+        ///The prepared statement for `GetPeopleByIds`.
+        pub GetPeopleByIds: scylla::statement::prepared_statement::PreparedStatement,
+        #[allow(non_snake_case)]
+        ///The prepared statement for `GetPersonByEmail`.
+        pub GetPersonByEmail: scylla::statement::prepared_statement::PreparedStatement,
+    }
+    ///A collection of prepared statements.
+    impl scyllax::Queries for PersonEntityQueries {
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn new<'life0, 'async_trait>(
+            session: &'life0 scylla::Session,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<Self, scyllax::ScyllaxError>,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<Self, scyllax::ScyllaxError>,
+                    > {
+                    return __ret;
                 }
-            }
-        }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for PersonData {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field1_finish(
-                    f,
-                    "PersonData",
-                    "stripe_id",
-                    &&self.stripe_id,
-                )
-            }
-        }
-        #[automatically_derived]
-        impl ::core::marker::StructuralPartialEq for PersonData {}
-        #[automatically_derived]
-        impl ::core::cmp::PartialEq for PersonData {
-            #[inline]
-            fn eq(&self, other: &PersonData) -> bool {
-                self.stripe_id == other.stripe_id
-            }
-        }
-        #[doc(hidden)]
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-        const _: () = {
-            #[allow(unused_extern_crates, clippy::useless_attribute)]
-            extern crate serde as _serde;
-            #[automatically_derived]
-            impl _serde::Serialize for PersonData {
-                fn serialize<__S>(
-                    &self,
-                    __serializer: __S,
-                ) -> _serde::__private::Result<__S::Ok, __S::Error>
-                where
-                    __S: _serde::Serializer,
-                {
-                    let mut __serde_state = _serde::Serializer::serialize_struct(
-                        __serializer,
-                        "PersonData",
-                        false as usize + 1,
-                    )?;
-                    _serde::ser::SerializeStruct::serialize_field(
-                        &mut __serde_state,
-                        "stripeId",
-                        &self.stripe_id,
-                    )?;
-                    _serde::ser::SerializeStruct::end(__serde_state)
-                }
-            }
-        };
-        #[doc(hidden)]
-        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-        const _: () = {
-            #[allow(unused_extern_crates, clippy::useless_attribute)]
-            extern crate serde as _serde;
-            #[automatically_derived]
-            impl<'de> _serde::Deserialize<'de> for PersonData {
-                fn deserialize<__D>(
-                    __deserializer: __D,
-                ) -> _serde::__private::Result<Self, __D::Error>
-                where
-                    __D: _serde::Deserializer<'de>,
-                {
-                    #[allow(non_camel_case_types)]
-                    #[doc(hidden)]
-                    enum __Field {
-                        __field0,
-                        __ignore,
-                    }
-                    #[doc(hidden)]
-                    struct __FieldVisitor;
-                    impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
-                        type Value = __Field;
-                        fn expecting(
-                            &self,
-                            __formatter: &mut _serde::__private::Formatter,
-                        ) -> _serde::__private::fmt::Result {
-                            _serde::__private::Formatter::write_str(
-                                __formatter,
-                                "field identifier",
-                            )
-                        }
-                        fn visit_u64<__E>(
-                            self,
-                            __value: u64,
-                        ) -> _serde::__private::Result<Self::Value, __E>
-                        where
-                            __E: _serde::de::Error,
-                        {
-                            match __value {
-                                0u64 => _serde::__private::Ok(__Field::__field0),
-                                _ => _serde::__private::Ok(__Field::__ignore),
-                            }
-                        }
-                        fn visit_str<__E>(
-                            self,
-                            __value: &str,
-                        ) -> _serde::__private::Result<Self::Value, __E>
-                        where
-                            __E: _serde::de::Error,
-                        {
-                            match __value {
-                                "stripeId" => _serde::__private::Ok(__Field::__field0),
-                                _ => _serde::__private::Ok(__Field::__ignore),
-                            }
-                        }
-                        fn visit_bytes<__E>(
-                            self,
-                            __value: &[u8],
-                        ) -> _serde::__private::Result<Self::Value, __E>
-                        where
-                            __E: _serde::de::Error,
-                        {
-                            match __value {
-                                b"stripeId" => _serde::__private::Ok(__Field::__field0),
-                                _ => _serde::__private::Ok(__Field::__ignore),
-                            }
-                        }
-                    }
-                    impl<'de> _serde::Deserialize<'de> for __Field {
-                        #[inline]
-                        fn deserialize<__D>(
-                            __deserializer: __D,
-                        ) -> _serde::__private::Result<Self, __D::Error>
-                        where
-                            __D: _serde::Deserializer<'de>,
-                        {
-                            _serde::Deserializer::deserialize_identifier(
-                                __deserializer,
-                                __FieldVisitor,
-                            )
-                        }
-                    }
-                    #[doc(hidden)]
-                    struct __Visitor<'de> {
-                        marker: _serde::__private::PhantomData<PersonData>,
-                        lifetime: _serde::__private::PhantomData<&'de ()>,
-                    }
-                    impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
-                        type Value = PersonData;
-                        fn expecting(
-                            &self,
-                            __formatter: &mut _serde::__private::Formatter,
-                        ) -> _serde::__private::fmt::Result {
-                            _serde::__private::Formatter::write_str(
-                                __formatter,
-                                "struct PersonData",
-                            )
-                        }
-                        #[inline]
-                        fn visit_seq<__A>(
-                            self,
-                            mut __seq: __A,
-                        ) -> _serde::__private::Result<Self::Value, __A::Error>
-                        where
-                            __A: _serde::de::SeqAccess<'de>,
-                        {
-                            let __field0 = match _serde::de::SeqAccess::next_element::<
-                                Option<String>,
-                            >(&mut __seq)? {
-                                _serde::__private::Some(__value) => __value,
-                                _serde::__private::None => {
-                                    return _serde::__private::Err(
-                                        _serde::de::Error::invalid_length(
-                                            0usize,
-                                            &"struct PersonData with 1 element",
-                                        ),
-                                    );
-                                }
-                            };
-                            _serde::__private::Ok(PersonData { stripe_id: __field0 })
-                        }
-                        #[inline]
-                        fn visit_map<__A>(
-                            self,
-                            mut __map: __A,
-                        ) -> _serde::__private::Result<Self::Value, __A::Error>
-                        where
-                            __A: _serde::de::MapAccess<'de>,
-                        {
-                            let mut __field0: _serde::__private::Option<
-                                Option<String>,
-                            > = _serde::__private::None;
-                            while let _serde::__private::Some(__key)
-                                = _serde::de::MapAccess::next_key::<__Field>(&mut __map)? {
-                                match __key {
-                                    __Field::__field0 => {
-                                        if _serde::__private::Option::is_some(&__field0) {
-                                            return _serde::__private::Err(
-                                                <__A::Error as _serde::de::Error>::duplicate_field(
-                                                    "stripeId",
-                                                ),
-                                            );
-                                        }
-                                        __field0 = _serde::__private::Some(
-                                            _serde::de::MapAccess::next_value::<
-                                                Option<String>,
-                                            >(&mut __map)?,
-                                        );
-                                    }
-                                    _ => {
-                                        let _ = _serde::de::MapAccess::next_value::<
-                                            _serde::de::IgnoredAny,
-                                        >(&mut __map)?;
-                                    }
-                                }
-                            }
-                            let __field0 = match __field0 {
-                                _serde::__private::Some(__field0) => __field0,
-                                _serde::__private::None => {
-                                    _serde::__private::de::missing_field("stripeId")?
-                                }
-                            };
-                            _serde::__private::Ok(PersonData { stripe_id: __field0 })
-                        }
-                    }
-                    #[doc(hidden)]
-                    const FIELDS: &'static [&'static str] = &["stripeId"];
-                    _serde::Deserializer::deserialize_struct(
-                        __deserializer,
-                        "PersonData",
-                        FIELDS,
-                        __Visitor {
-                            marker: _serde::__private::PhantomData::<PersonData>,
-                            lifetime: _serde::__private::PhantomData,
-                        },
-                    )
-                }
-            }
-        };
-        impl scylla::frame::value::Value for PersonData {
-            fn serialize(
-                &self,
-                buf: &mut Vec<u8>,
-            ) -> Result<(), scylla::frame::value::ValueTooBig> {
-                let data = serde_json::to_vec(self).unwrap();
-                <Vec<u8> as scylla::frame::value::Value>::serialize(&data, buf)
-            }
-        }
-        impl scylla::cql_to_rust::FromCqlVal<scylla::frame::response::result::CqlValue>
-        for PersonData {
-            fn from_cql(
-                cql_val: scylla::frame::response::result::CqlValue,
-            ) -> Result<Self, scylla::cql_to_rust::FromCqlValError> {
-                let data = <Vec<
-                    u8,
-                > as scylla::cql_to_rust::FromCqlVal<
-                    scylla::frame::response::result::CqlValue,
-                >>::from_cql(cql_val)?;
-                serde_json::from_slice(&data)
-                    .ok()
-                    .ok_or(scylla::cql_to_rust::FromCqlValError::BadCqlType)
-            }
-        }
-        /// Represents a person in the database
-        pub struct PersonEntity {
-            /// The id of the person
-            #[pk]
-            pub id: uuid::Uuid,
-            /// The email address of the person
-            pub email: String,
-            /// The age of the person
-            pub age: Option<i32>,
-            /// Other data from the person
-            pub data: Option<PersonData>,
-            /// The date the person was created
-            #[rename("createdAt")]
-            pub created_at: i64,
-        }
-        ///Upserts a PersonEntity into the `person` table
-        pub struct UpsertPerson {
-            ///The id of the PersonEntity
-            pub id: uuid::Uuid,
-            ///The email of the PersonEntity
-            pub email: scyllax::prelude::MaybeUnset<String>,
-            ///The age of the PersonEntity
-            pub age: scyllax::prelude::MaybeUnset<Option<i32>>,
-            ///The data of the PersonEntity
-            pub data: scyllax::prelude::MaybeUnset<Option<PersonData>>,
-            ///The created_at of the PersonEntity
-            pub created_at: scyllax::prelude::MaybeUnset<i64>,
-        }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for UpsertPerson {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field5_finish(
-                    f,
-                    "UpsertPerson",
-                    "id",
-                    &self.id,
-                    "email",
-                    &self.email,
-                    "age",
-                    &self.age,
-                    "data",
-                    &self.data,
-                    "created_at",
-                    &&self.created_at,
-                )
-            }
-        }
-        #[automatically_derived]
-        impl ::core::clone::Clone for UpsertPerson {
-            #[inline]
-            fn clone(&self) -> UpsertPerson {
-                UpsertPerson {
-                    id: ::core::clone::Clone::clone(&self.id),
-                    email: ::core::clone::Clone::clone(&self.email),
-                    age: ::core::clone::Clone::clone(&self.age),
-                    data: ::core::clone::Clone::clone(&self.data),
-                    created_at: ::core::clone::Clone::clone(&self.created_at),
-                }
-            }
-        }
-        impl scyllax::UpsertQuery<PersonEntity> for UpsertPerson {
-            fn query(
-                &self,
-            ) -> Result<
-                (String, scyllax::prelude::SerializedValues),
-                scyllax::BuildUpsertQueryError,
-            > {
-                let query = "update person set email = :email, age = :age, data = :data, \"createdAt\" = :created_at where id = :id;"
-                    .to_string();
-                let mut variables = scylla::frame::value::SerializedValues::new();
-                match variables.add_named_value("email", &self.email) {
-                    Ok(_) => {}
-                    Err(scylla::frame::value::SerializeValuesError::TooManyValues) => {
-                        return Err(scyllax::BuildUpsertQueryError::TooManyValues {
-                            field: "email".to_string(),
-                        });
-                    }
-                    Err(
-                        scylla::frame::value::SerializeValuesError::MixingNamedAndNotNamedValues,
-                    ) => {
-                        return Err(
-                            scyllax::BuildUpsertQueryError::MixingNamedAndNotNamedValues,
-                        );
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ValueTooBig(_)) => {
-                        return Err(scyllax::BuildUpsertQueryError::ValueTooBig {
-                            field: "email".to_string(),
-                        });
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ParseError) => {
-                        return Err(scyllax::BuildUpsertQueryError::ParseError {
-                            field: "email".to_string(),
-                        });
-                    }
+                let __ret: Result<Self, scyllax::ScyllaxError> = {
+                    Ok(Self {
+                        GetPersonById: session.prepare(GetPersonById::query()).await?,
+                        GetPeopleByIds: session.prepare(GetPeopleByIds::query()).await?,
+                        GetPersonByEmail: session
+                            .prepare(GetPersonByEmail::query())
+                            .await?,
+                    })
                 };
-                match variables.add_named_value("age", &self.age) {
-                    Ok(_) => {}
-                    Err(scylla::frame::value::SerializeValuesError::TooManyValues) => {
-                        return Err(scyllax::BuildUpsertQueryError::TooManyValues {
-                            field: "age".to_string(),
-                        });
-                    }
-                    Err(
-                        scylla::frame::value::SerializeValuesError::MixingNamedAndNotNamedValues,
-                    ) => {
-                        return Err(
-                            scyllax::BuildUpsertQueryError::MixingNamedAndNotNamedValues,
-                        );
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ValueTooBig(_)) => {
-                        return Err(scyllax::BuildUpsertQueryError::ValueTooBig {
-                            field: "age".to_string(),
-                        });
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ParseError) => {
-                        return Err(scyllax::BuildUpsertQueryError::ParseError {
-                            field: "age".to_string(),
-                        });
-                    }
-                };
-                match variables.add_named_value("data", &self.data) {
-                    Ok(_) => {}
-                    Err(scylla::frame::value::SerializeValuesError::TooManyValues) => {
-                        return Err(scyllax::BuildUpsertQueryError::TooManyValues {
-                            field: "data".to_string(),
-                        });
-                    }
-                    Err(
-                        scylla::frame::value::SerializeValuesError::MixingNamedAndNotNamedValues,
-                    ) => {
-                        return Err(
-                            scyllax::BuildUpsertQueryError::MixingNamedAndNotNamedValues,
-                        );
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ValueTooBig(_)) => {
-                        return Err(scyllax::BuildUpsertQueryError::ValueTooBig {
-                            field: "data".to_string(),
-                        });
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ParseError) => {
-                        return Err(scyllax::BuildUpsertQueryError::ParseError {
-                            field: "data".to_string(),
-                        });
-                    }
-                };
-                match variables.add_named_value("created_at", &self.created_at) {
-                    Ok(_) => {}
-                    Err(scylla::frame::value::SerializeValuesError::TooManyValues) => {
-                        return Err(scyllax::BuildUpsertQueryError::TooManyValues {
-                            field: "created_at".to_string(),
-                        });
-                    }
-                    Err(
-                        scylla::frame::value::SerializeValuesError::MixingNamedAndNotNamedValues,
-                    ) => {
-                        return Err(
-                            scyllax::BuildUpsertQueryError::MixingNamedAndNotNamedValues,
-                        );
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ValueTooBig(_)) => {
-                        return Err(scyllax::BuildUpsertQueryError::ValueTooBig {
-                            field: "created_at".to_string(),
-                        });
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ParseError) => {
-                        return Err(scyllax::BuildUpsertQueryError::ParseError {
-                            field: "created_at".to_string(),
-                        });
-                    }
-                };
-                match variables.add_named_value("id", &self.id) {
-                    Ok(_) => {}
-                    Err(scylla::frame::value::SerializeValuesError::TooManyValues) => {
-                        return Err(scyllax::BuildUpsertQueryError::TooManyValues {
-                            field: "id".to_string(),
-                        });
-                    }
-                    Err(
-                        scylla::frame::value::SerializeValuesError::MixingNamedAndNotNamedValues,
-                    ) => {
-                        return Err(
-                            scyllax::BuildUpsertQueryError::MixingNamedAndNotNamedValues,
-                        );
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ValueTooBig(_)) => {
-                        return Err(scyllax::BuildUpsertQueryError::ValueTooBig {
-                            field: "id".to_string(),
-                        });
-                    }
-                    Err(scylla::frame::value::SerializeValuesError::ParseError) => {
-                        return Err(scyllax::BuildUpsertQueryError::ParseError {
-                            field: "id".to_string(),
-                        });
-                    }
-                };
-                Ok((query, variables))
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn execute<'life0, 'async_trait>(
-                self,
-                db: &'life0 scyllax::Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<scyllax::QueryResult, scyllax::ScyllaxError>,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<scyllax::QueryResult, scyllax::ScyllaxError>,
-                        > {
-                        return __ret;
-                    }
-                    let __self = self;
-                    let __ret: Result<scyllax::QueryResult, scyllax::ScyllaxError> = {
-                        let (query, values) = Self::query(&__self)?;
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/model.rs:13",
-                                        "example::entities::person::model",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/model.rs"),
-                                        Some(13u32),
-                                        Some("example::entities::person::model"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message", "query", "values"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
-                            };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&format_args!("executing upsert") as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&debug(&query) as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&values.len() as &dyn Value),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
-                        };
-                        db.session.execute(query, values).await.map_err(|e| e.into())
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
+                #[allow(unreachable_code)] __ret
+            })
         }
-        #[automatically_derived]
-        impl ::core::clone::Clone for PersonEntity {
-            #[inline]
-            fn clone(&self) -> PersonEntity {
-                PersonEntity {
-                    id: ::core::clone::Clone::clone(&self.id),
-                    email: ::core::clone::Clone::clone(&self.email),
-                    age: ::core::clone::Clone::clone(&self.age),
-                    data: ::core::clone::Clone::clone(&self.data),
-                    created_at: ::core::clone::Clone::clone(&self.created_at),
-                }
-            }
+        ///Get a prepared statement.
+        fn get<T>(&self) -> &scylla::statement::prepared_statement::PreparedStatement
+        where
+            Self: scyllax::GetPreparedStatement<T>,
+        {
+            <Self as scyllax::GetPreparedStatement<T>>::get_prepared_statement(self)
         }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for PersonEntity {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field5_finish(
-                    f,
-                    "PersonEntity",
-                    "id",
-                    &self.id,
-                    "email",
-                    &self.email,
-                    "age",
-                    &self.age,
-                    "data",
-                    &self.data,
-                    "created_at",
-                    &&self.created_at,
-                )
-            }
+    }
+    impl scyllax::GetPreparedStatement<GetPersonById> for PersonEntityQueries {
+        ///Get a prepared statement.
+        fn get_prepared_statement(
+            &self,
+        ) -> &scylla::statement::prepared_statement::PreparedStatement {
+            &self.GetPersonById
         }
-        #[automatically_derived]
-        impl ::core::marker::StructuralPartialEq for PersonEntity {}
-        #[automatically_derived]
-        impl ::core::cmp::PartialEq for PersonEntity {
-            #[inline]
-            fn eq(&self, other: &PersonEntity) -> bool {
-                self.id == other.id && self.email == other.email && self.age == other.age
-                    && self.data == other.data && self.created_at == other.created_at
-            }
+    }
+    impl scyllax::GetPreparedStatement<GetPeopleByIds> for PersonEntityQueries {
+        ///Get a prepared statement.
+        fn get_prepared_statement(
+            &self,
+        ) -> &scylla::statement::prepared_statement::PreparedStatement {
+            &self.GetPeopleByIds
         }
-        impl scylla::_macro_internal::FromRow for PersonEntity {
-            fn from_row(
-                row: scylla::_macro_internal::Row,
-            ) -> ::std::result::Result<Self, scylla::_macro_internal::FromRowError> {
-                use scylla::_macro_internal::{
-                    CqlValue, FromCqlVal, FromRow, FromRowError,
-                };
-                use ::std::result::Result::{Ok, Err};
-                use ::std::iter::{Iterator, IntoIterator};
-                if 5usize != row.columns.len() {
-                    return Err(FromRowError::WrongRowSize {
-                        expected: 5usize,
-                        actual: row.columns.len(),
-                    });
-                }
-                let mut vals_iter = row.columns.into_iter().enumerate();
-                Ok(PersonEntity {
-                    id: {
-                        let (col_ix, col_value) = vals_iter.next().unwrap();
-                        <uuid::Uuid as FromCqlVal<
-                            ::std::option::Option<CqlValue>,
-                        >>::from_cql(col_value)
-                            .map_err(|e| FromRowError::BadCqlVal {
-                                err: e,
-                                column: col_ix,
-                            })?
-                    },
-                    email: {
-                        let (col_ix, col_value) = vals_iter.next().unwrap();
-                        <String as FromCqlVal<
-                            ::std::option::Option<CqlValue>,
-                        >>::from_cql(col_value)
-                            .map_err(|e| FromRowError::BadCqlVal {
-                                err: e,
-                                column: col_ix,
-                            })?
-                    },
-                    age: {
-                        let (col_ix, col_value) = vals_iter.next().unwrap();
-                        <Option<
-                            i32,
-                        > as FromCqlVal<
-                            ::std::option::Option<CqlValue>,
-                        >>::from_cql(col_value)
-                            .map_err(|e| FromRowError::BadCqlVal {
-                                err: e,
-                                column: col_ix,
-                            })?
-                    },
-                    data: {
-                        let (col_ix, col_value) = vals_iter.next().unwrap();
-                        <Option<
-                            PersonData,
-                        > as FromCqlVal<
-                            ::std::option::Option<CqlValue>,
-                        >>::from_cql(col_value)
-                            .map_err(|e| FromRowError::BadCqlVal {
-                                err: e,
-                                column: col_ix,
-                            })?
-                    },
-                    created_at: {
-                        let (col_ix, col_value) = vals_iter.next().unwrap();
-                        <i64 as FromCqlVal<
-                            ::std::option::Option<CqlValue>,
-                        >>::from_cql(col_value)
-                            .map_err(|e| FromRowError::BadCqlVal {
-                                err: e,
-                                column: col_ix,
-                            })?
-                    },
-                })
-            }
+    }
+    impl scyllax::GetPreparedStatement<GetPersonByEmail> for PersonEntityQueries {
+        ///Get a prepared statement.
+        fn get_prepared_statement(
+            &self,
+        ) -> &scylla::statement::prepared_statement::PreparedStatement {
+            &self.GetPersonByEmail
         }
-        impl scylla::_macro_internal::ValueList for PersonEntity {
-            fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
-                let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
-                    5usize,
-                );
-                result.add_value(&self.id)?;
-                result.add_value(&self.email)?;
-                result.add_value(&self.age)?;
-                result.add_value(&self.data)?;
-                result.add_value(&self.created_at)?;
-                ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
-            }
+    }
+    /// Get a [`super::model::PersonEntity`] by its [`uuid::Uuid`]
+    pub struct GetPersonById {
+        /// The [`uuid::Uuid`] of the [`super::model::PersonEntity`] to get
+        pub id: Uuid,
+    }
+    impl scylla::_macro_internal::ValueList for GetPersonById {
+        fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
+            let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
+                1usize,
+            );
+            result.add_value(&self.id)?;
+            ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
         }
-        impl scyllax::EntityExt<PersonEntity> for PersonEntity {
-            fn keys() -> Vec<String> {
-                <[_]>::into_vec(
-                    #[rustc_box]
-                    ::alloc::boxed::Box::new([
-                        "id".to_string(),
-                        "email".to_string(),
-                        "age".to_string(),
-                        "data".to_string(),
-                        "\"createdAt\"".to_string(),
-                    ]),
-                )
+    }
+    impl scylla::_macro_internal::FromRow for GetPersonById {
+        fn from_row(
+            row: scylla::_macro_internal::Row,
+        ) -> ::std::result::Result<Self, scylla::_macro_internal::FromRowError> {
+            use scylla::_macro_internal::{CqlValue, FromCqlVal, FromRow, FromRowError};
+            use ::std::result::Result::{Ok, Err};
+            use ::std::iter::{Iterator, IntoIterator};
+            if 1usize != row.columns.len() {
+                return Err(FromRowError::WrongRowSize {
+                    expected: 1usize,
+                    actual: row.columns.len(),
+                });
             }
-            fn pks() -> Vec<String> {
-                <[_]>::into_vec(
-                    #[rustc_box]
-                    ::alloc::boxed::Box::new(["id".to_string()]),
-                )
+            let mut vals_iter = row.columns.into_iter().enumerate();
+            Ok(GetPersonById {
+                id: {
+                    let (col_ix, col_value) = vals_iter.next().unwrap();
+                    <Uuid as FromCqlVal<
+                        ::std::option::Option<CqlValue>,
+                    >>::from_cql(col_value)
+                        .map_err(|e| FromRowError::BadCqlVal {
+                            err: e,
+                            column: col_ix,
+                        })?
+                },
+            })
+        }
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for GetPersonById {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field1_finish(
+                f,
+                "GetPersonById",
+                "id",
+                &&self.id,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for GetPersonById {
+        #[inline]
+        fn clone(&self) -> GetPersonById {
+            GetPersonById {
+                id: ::core::clone::Clone::clone(&self.id),
             }
         }
     }
-    /// All select queries
-    pub mod queries {
-        use scyllax::{delete_query, prelude::*};
-        use uuid::Uuid;
-        /// Load all queries for this entity
-        pub async fn load(db: &mut Executor) -> anyhow::Result<()> {
-            {}
-            let __tracing_attr_span = {
-                use ::tracing::__macro_support::Callsite as _;
-                static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                    static META: ::tracing::Metadata<'static> = {
-                        ::tracing_core::metadata::Metadata::new(
-                            "load",
-                            "example::entities::person::queries",
-                            tracing::Level::INFO,
-                            Some("example/src/entities/person/queries.rs"),
-                            Some(5u32),
-                            Some("example::entities::person::queries"),
-                            ::tracing_core::field::FieldSet::new(
-                                &[],
-                                ::tracing_core::callsite::Identifier(&CALLSITE),
-                            ),
-                            ::tracing::metadata::Kind::SPAN,
-                        )
-                    };
-                    ::tracing::callsite::DefaultCallsite::new(&META)
-                };
-                let mut interest = ::tracing::subscriber::Interest::never();
-                if tracing::Level::INFO <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                    && tracing::Level::INFO
-                        <= ::tracing::level_filters::LevelFilter::current()
-                    && {
-                        interest = CALLSITE.interest();
-                        !interest.is_never()
-                    }
-                    && ::tracing::__macro_support::__is_enabled(
-                        CALLSITE.metadata(),
-                        interest,
-                    )
-                {
-                    let meta = CALLSITE.metadata();
-                    ::tracing::Span::new(meta, &{ meta.fields().value_set(&[]) })
-                } else {
-                    let span = ::tracing::__macro_support::__disabled_span(
-                        CALLSITE.metadata(),
-                    );
-                    {};
-                    span
-                }
-            };
-            let __tracing_instrument_future = async move {
-                #[allow(
-                    unknown_lints,
-                    unreachable_code,
-                    clippy::diverging_sub_expression,
-                    clippy::let_unit_value,
-                    clippy::unreachable,
-                    clippy::let_with_type_underscore
-                )]
-                if false {
-                    let __tracing_attr_fake_return: anyhow::Result<()> = {
-                        ::core::panicking::panic_fmt(
-                            format_args!(
-                                "internal error: entered unreachable code: {0}",
-                                format_args!(
-                                    "this is just for type inference, and is unreachable code",
-                                ),
-                            ),
-                        );
-                    };
-                    return __tracing_attr_fake_return;
-                }
-                {
-                    let _ = GetPersonById::prepare(db).await;
-                    let _ = GetPeopleByIds::prepare(db).await;
-                    let _ = GetPersonByEmail::prepare(db).await;
-                    let _ = DeletePersonById::prepare(db).await;
-                    Ok(())
-                }
-            };
-            if !__tracing_attr_span.is_disabled() {
-                tracing::Instrument::instrument(
-                        __tracing_instrument_future,
-                        __tracing_attr_span,
-                    )
-                    .await
-            } else {
-                __tracing_instrument_future.await
-            }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for GetPersonById {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for GetPersonById {
+        #[inline]
+        fn eq(&self, other: &GetPersonById) -> bool {
+            self.id == other.id
         }
-        /// Get a [`super::model::PersonEntity`] by its [`uuid::Uuid`]
-        pub struct GetPersonById {
-            /// The [`uuid::Uuid`] of the [`super::model::PersonEntity`] to get
-            pub id: Uuid,
+    }
+    #[automatically_derived]
+    impl ::core::hash::Hash for GetPersonById {
+        fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+            ::core::hash::Hash::hash(&self.id, state)
         }
-        impl scylla::_macro_internal::ValueList for GetPersonById {
-            fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
-                let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
-                    1usize,
-                );
-                result.add_value(&self.id)?;
-                ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
-            }
+    }
+    impl scyllax::GenericQuery<super::model::PersonEntity> for GetPersonById {
+        fn query() -> String {
+            "select * from person where id = ? limit 1"
+                .replace("*", &super::model::PersonEntity::keys().join(", "))
         }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for GetPersonById {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field1_finish(
-                    f,
-                    "GetPersonById",
-                    "id",
-                    &&self.id,
-                )
-            }
-        }
-        #[automatically_derived]
-        impl ::core::clone::Clone for GetPersonById {
-            #[inline]
-            fn clone(&self) -> GetPersonById {
-                GetPersonById {
-                    id: ::core::clone::Clone::clone(&self.id),
-                }
-            }
-        }
-        #[automatically_derived]
-        impl ::core::marker::StructuralPartialEq for GetPersonById {}
-        #[automatically_derived]
-        impl ::core::cmp::PartialEq for GetPersonById {
-            #[inline]
-            fn eq(&self, other: &GetPersonById) -> bool {
-                self.id == other.id
-            }
-        }
-        #[automatically_derived]
-        impl ::core::hash::Hash for GetPersonById {
-            fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
-                ::core::hash::Hash::hash(&self.id, state)
-            }
-        }
-        impl scyllax::SelectQuery<
-            super::model::PersonEntity,
-            Option<super::model::PersonEntity>,
-        > for GetPersonById {
-            fn query() -> String {
-                "select * from person where id = ? limit 1"
-                    .replace("*", &super::model::PersonEntity::keys().join(", "))
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn prepare<'life0, 'async_trait>(
-                db: &'life0 Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            scylla::prepared_statement::PreparedStatement,
-                            scylla::transport::errors::QueryError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                scylla::prepared_statement::PreparedStatement,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let __ret: Result<
-                        scylla::prepared_statement::PreparedStatement,
+    }
+    impl scyllax::SelectQuery<
+        super::model::PersonEntity,
+        Option<super::model::PersonEntity>,
+        super::model::PersonEntity,
+    > for GetPersonById {
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn execute<'life0, 'async_trait>(
+            self,
+            db: &'life0 scyllax::Executor<super::model::PersonEntity>,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<
+                        scylla::QueryResult,
                         scylla::transport::errors::QueryError,
-                    > = {
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:16",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(16u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
-                            };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(
-                                                        &format_args!("preparing query {0}", "GetPersonById")
-                                                            as &dyn Value,
-                                                    ),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
-                        };
-                        db.session
-                            .add_prepared_statement(
-                                &scylla::query::Query::new(Self::query()),
-                            )
-                            .await
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn execute<'life0, 'async_trait>(
-                self,
-                db: &'life0 scyllax::Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = anyhow::Result<
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<
                             scylla::QueryResult,
                             scylla::transport::errors::QueryError,
                         >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            anyhow::Result<
-                                scylla::QueryResult,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let __self = self;
-                    let __ret: anyhow::Result<
-                        scylla::QueryResult,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        let query = Self::query();
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:16",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(16u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message", "query"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
+                    > {
+                    return __ret;
+                }
+                let __self = self;
+                let __ret: Result<
+                    scylla::QueryResult,
+                    scylla::transport::errors::QueryError,
+                > = {
+                    let statement = db.queries.get::<GetPersonById>();
+                    {
+                        use ::tracing::__macro_support::Callsite as _;
+                        static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                            static META: ::tracing::Metadata<'static> = {
+                                ::tracing_core::metadata::Metadata::new(
+                                    "event example/src/entities/person/queries.rs:19",
+                                    "example::entities::person::queries",
+                                    ::tracing::Level::DEBUG,
+                                    Some("example/src/entities/person/queries.rs"),
+                                    Some(19u32),
+                                    Some("example::entities::person::queries"),
+                                    ::tracing_core::field::FieldSet::new(
+                                        &["message"],
+                                        ::tracing_core::callsite::Identifier(&CALLSITE),
+                                    ),
+                                    ::tracing::metadata::Kind::EVENT,
+                                )
                             };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&format_args!("executing select") as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&query as &dyn Value),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
+                            ::tracing::callsite::DefaultCallsite::new(&META)
                         };
-                        db.session.execute(query, __self).await
+                        let enabled = ::tracing::Level::DEBUG
+                            <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                            && ::tracing::Level::DEBUG
+                                <= ::tracing::level_filters::LevelFilter::current()
+                            && {
+                                let interest = CALLSITE.interest();
+                                !interest.is_never()
+                                    && ::tracing::__macro_support::__is_enabled(
+                                        CALLSITE.metadata(),
+                                        interest,
+                                    )
+                            };
+                        if enabled {
+                            (|value_set: ::tracing::field::ValueSet| {
+                                let meta = CALLSITE.metadata();
+                                ::tracing::Event::dispatch(meta, &value_set);
+                            })({
+                                #[allow(unused_imports)]
+                                use ::tracing::field::{debug, display, Value};
+                                let mut iter = CALLSITE.metadata().fields().iter();
+                                CALLSITE
+                                    .metadata()
+                                    .fields()
+                                    .value_set(
+                                        &[
+                                            (
+                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                Some(&format_args!("executing select") as &dyn Value),
+                                            ),
+                                        ],
+                                    )
+                            });
+                        } else {
+                        }
                     };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn parse_response<'async_trait>(
-                res: scylla::QueryResult,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            Option<super::model::PersonEntity>,
-                            scyllax::ScyllaxError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            > {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                Option<super::model::PersonEntity>,
-                                scyllax::ScyllaxError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let res = res;
-                    let __ret: Result<
+                    db.session.execute(statement, __self).await
+                };
+                #[allow(unreachable_code)] __ret
+            })
+        }
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn parse_response<'async_trait>(
+            res: scylla::QueryResult,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<
                         Option<super::model::PersonEntity>,
                         scyllax::ScyllaxError,
-                    > = {
-                        match res.single_row_typed::<super::model::PersonEntity>() {
-                            Ok(data) => Ok(Some(data)),
-                            Err(err) => {
-                                use scylla::transport::query_result::SingleRowTypedError;
-                                match err {
-                                    SingleRowTypedError::BadNumberOfRows(_) => Ok(None),
-                                    _ => {
-                                        {
-                                            use ::tracing::__macro_support::Callsite as _;
-                                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                                static META: ::tracing::Metadata<'static> = {
-                                                    ::tracing_core::metadata::Metadata::new(
-                                                        "event example/src/entities/person/queries.rs:16",
-                                                        "example::entities::person::queries",
-                                                        ::tracing::Level::ERROR,
-                                                        Some("example/src/entities/person/queries.rs"),
-                                                        Some(16u32),
-                                                        Some("example::entities::person::queries"),
-                                                        ::tracing_core::field::FieldSet::new(
-                                                            &["message"],
-                                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                                        ),
-                                                        ::tracing::metadata::Kind::EVENT,
-                                                    )
-                                                };
-                                                ::tracing::callsite::DefaultCallsite::new(&META)
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        > {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<Option<super::model::PersonEntity>, scyllax::ScyllaxError>,
+                    > {
+                    return __ret;
+                }
+                let res = res;
+                let __ret: Result<
+                    Option<super::model::PersonEntity>,
+                    scyllax::ScyllaxError,
+                > = {
+                    match res.single_row_typed::<super::model::PersonEntity>() {
+                        Ok(data) => Ok(Some(data)),
+                        Err(err) => {
+                            use scylla::transport::query_result::SingleRowTypedError;
+                            match err {
+                                SingleRowTypedError::BadNumberOfRows(_) => Ok(None),
+                                _ => {
+                                    {
+                                        use ::tracing::__macro_support::Callsite as _;
+                                        static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                                            static META: ::tracing::Metadata<'static> = {
+                                                ::tracing_core::metadata::Metadata::new(
+                                                    "event example/src/entities/person/queries.rs:19",
+                                                    "example::entities::person::queries",
+                                                    ::tracing::Level::ERROR,
+                                                    Some("example/src/entities/person/queries.rs"),
+                                                    Some(19u32),
+                                                    Some("example::entities::person::queries"),
+                                                    ::tracing_core::field::FieldSet::new(
+                                                        &["message"],
+                                                        ::tracing_core::callsite::Identifier(&CALLSITE),
+                                                    ),
+                                                    ::tracing::metadata::Kind::EVENT,
+                                                )
                                             };
-                                            let enabled = ::tracing::Level::ERROR
-                                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                                && ::tracing::Level::ERROR
-                                                    <= ::tracing::level_filters::LevelFilter::current()
-                                                && {
-                                                    let interest = CALLSITE.interest();
-                                                    !interest.is_never()
-                                                        && ::tracing::__macro_support::__is_enabled(
-                                                            CALLSITE.metadata(),
-                                                            interest,
-                                                        )
-                                                };
-                                            if enabled {
-                                                (|value_set: ::tracing::field::ValueSet| {
-                                                    let meta = CALLSITE.metadata();
-                                                    ::tracing::Event::dispatch(meta, &value_set);
-                                                })({
-                                                    #[allow(unused_imports)]
-                                                    use ::tracing::field::{debug, display, Value};
-                                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                                    CALLSITE
-                                                        .metadata()
-                                                        .fields()
-                                                        .value_set(
-                                                            &[
-                                                                (
-                                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                                    Some(&format_args!("err: {0:?}", err) as &dyn Value),
-                                                                ),
-                                                            ],
-                                                        )
-                                                });
-                                            } else {
-                                            }
+                                            ::tracing::callsite::DefaultCallsite::new(&META)
                                         };
-                                        Err(scyllax::ScyllaxError::SingleRowTyped(err))
-                                    }
+                                        let enabled = ::tracing::Level::ERROR
+                                            <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                                            && ::tracing::Level::ERROR
+                                                <= ::tracing::level_filters::LevelFilter::current()
+                                            && {
+                                                let interest = CALLSITE.interest();
+                                                !interest.is_never()
+                                                    && ::tracing::__macro_support::__is_enabled(
+                                                        CALLSITE.metadata(),
+                                                        interest,
+                                                    )
+                                            };
+                                        if enabled {
+                                            (|value_set: ::tracing::field::ValueSet| {
+                                                let meta = CALLSITE.metadata();
+                                                ::tracing::Event::dispatch(meta, &value_set);
+                                            })({
+                                                #[allow(unused_imports)]
+                                                use ::tracing::field::{debug, display, Value};
+                                                let mut iter = CALLSITE.metadata().fields().iter();
+                                                CALLSITE
+                                                    .metadata()
+                                                    .fields()
+                                                    .value_set(
+                                                        &[
+                                                            (
+                                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                                Some(&format_args!("err: {0:?}", err) as &dyn Value),
+                                                            ),
+                                                        ],
+                                                    )
+                                            });
+                                        } else {
+                                        }
+                                    };
+                                    Err(scyllax::ScyllaxError::SingleRowTyped(err))
                                 }
                             }
                         }
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-        }
-        /// Get many [`super::model::PersonEntity`] by many [`uuid::Uuid`]
-        pub struct GetPeopleByIds {
-            /// The [`uuid::Uuid`]s of the [`super::model::PersonEntity`]s to get
-            pub ids: Vec<Uuid>,
-            /// The maximum number of [`super::model::PersonEntity`]s to get
-            pub limit: i32,
-        }
-        impl scylla::_macro_internal::ValueList for GetPeopleByIds {
-            fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
-                let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
-                    2usize,
-                );
-                result.add_value(&self.ids)?;
-                result.add_value(&self.limit)?;
-                ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
-            }
-        }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for GetPeopleByIds {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field2_finish(
-                    f,
-                    "GetPeopleByIds",
-                    "ids",
-                    &self.ids,
-                    "limit",
-                    &&self.limit,
-                )
-            }
-        }
-        #[automatically_derived]
-        impl ::core::clone::Clone for GetPeopleByIds {
-            #[inline]
-            fn clone(&self) -> GetPeopleByIds {
-                GetPeopleByIds {
-                    ids: ::core::clone::Clone::clone(&self.ids),
-                    limit: ::core::clone::Clone::clone(&self.limit),
-                }
-            }
-        }
-        #[automatically_derived]
-        impl ::core::marker::StructuralPartialEq for GetPeopleByIds {}
-        #[automatically_derived]
-        impl ::core::cmp::PartialEq for GetPeopleByIds {
-            #[inline]
-            fn eq(&self, other: &GetPeopleByIds) -> bool {
-                self.ids == other.ids && self.limit == other.limit
-            }
-        }
-        #[automatically_derived]
-        impl ::core::hash::Hash for GetPeopleByIds {
-            fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
-                ::core::hash::Hash::hash(&self.ids, state);
-                ::core::hash::Hash::hash(&self.limit, state)
-            }
-        }
-        impl scyllax::SelectQuery<
-            super::model::PersonEntity,
-            Vec<super::model::PersonEntity>,
-        > for GetPeopleByIds {
-            fn query() -> String {
-                "select * from person where id in ? limit ?"
-                    .replace("*", &super::model::PersonEntity::keys().join(", "))
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn prepare<'life0, 'async_trait>(
-                db: &'life0 Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            scylla::prepared_statement::PreparedStatement,
-                            scylla::transport::errors::QueryError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                scylla::prepared_statement::PreparedStatement,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
                     }
-                    let __ret: Result<
-                        scylla::prepared_statement::PreparedStatement,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:26",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(26u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
-                            };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(
-                                                        &format_args!("preparing query {0}", "GetPeopleByIds")
-                                                            as &dyn Value,
-                                                    ),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
-                        };
-                        db.session
-                            .add_prepared_statement(
-                                &scylla::query::Query::new(Self::query()),
-                            )
-                            .await
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
+                };
+                #[allow(unreachable_code)] __ret
+            })
+        }
+    }
+    /// Get many [`super::model::PersonEntity`] by many [`uuid::Uuid`]
+    pub struct GetPeopleByIds {
+        /// The [`uuid::Uuid`]s of the [`super::model::PersonEntity`]s to get
+        pub ids: Vec<Uuid>,
+        /// The maximum number of [`super::model::PersonEntity`]s to get
+        pub limit: i32,
+    }
+    impl scylla::_macro_internal::ValueList for GetPeopleByIds {
+        fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
+            let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
+                2usize,
+            );
+            result.add_value(&self.ids)?;
+            result.add_value(&self.limit)?;
+            ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
+        }
+    }
+    impl scylla::_macro_internal::FromRow for GetPeopleByIds {
+        fn from_row(
+            row: scylla::_macro_internal::Row,
+        ) -> ::std::result::Result<Self, scylla::_macro_internal::FromRowError> {
+            use scylla::_macro_internal::{CqlValue, FromCqlVal, FromRow, FromRowError};
+            use ::std::result::Result::{Ok, Err};
+            use ::std::iter::{Iterator, IntoIterator};
+            if 2usize != row.columns.len() {
+                return Err(FromRowError::WrongRowSize {
+                    expected: 2usize,
+                    actual: row.columns.len(),
+                });
             }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn execute<'life0, 'async_trait>(
-                self,
-                db: &'life0 scyllax::Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = anyhow::Result<
+            let mut vals_iter = row.columns.into_iter().enumerate();
+            Ok(GetPeopleByIds {
+                ids: {
+                    let (col_ix, col_value) = vals_iter.next().unwrap();
+                    <Vec<
+                        Uuid,
+                    > as FromCqlVal<
+                        ::std::option::Option<CqlValue>,
+                    >>::from_cql(col_value)
+                        .map_err(|e| FromRowError::BadCqlVal {
+                            err: e,
+                            column: col_ix,
+                        })?
+                },
+                limit: {
+                    let (col_ix, col_value) = vals_iter.next().unwrap();
+                    <i32 as FromCqlVal<
+                        ::std::option::Option<CqlValue>,
+                    >>::from_cql(col_value)
+                        .map_err(|e| FromRowError::BadCqlVal {
+                            err: e,
+                            column: col_ix,
+                        })?
+                },
+            })
+        }
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for GetPeopleByIds {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field2_finish(
+                f,
+                "GetPeopleByIds",
+                "ids",
+                &self.ids,
+                "limit",
+                &&self.limit,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for GetPeopleByIds {
+        #[inline]
+        fn clone(&self) -> GetPeopleByIds {
+            GetPeopleByIds {
+                ids: ::core::clone::Clone::clone(&self.ids),
+                limit: ::core::clone::Clone::clone(&self.limit),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for GetPeopleByIds {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for GetPeopleByIds {
+        #[inline]
+        fn eq(&self, other: &GetPeopleByIds) -> bool {
+            self.ids == other.ids && self.limit == other.limit
+        }
+    }
+    #[automatically_derived]
+    impl ::core::hash::Hash for GetPeopleByIds {
+        fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+            ::core::hash::Hash::hash(&self.ids, state);
+            ::core::hash::Hash::hash(&self.limit, state)
+        }
+    }
+    impl scyllax::GenericQuery<super::model::PersonEntity> for GetPeopleByIds {
+        fn query() -> String {
+            "select * from person where id in ? limit ?"
+                .replace("*", &super::model::PersonEntity::keys().join(", "))
+        }
+    }
+    impl scyllax::SelectQuery<
+        super::model::PersonEntity,
+        Vec<super::model::PersonEntity>,
+        super::model::PersonEntity,
+    > for GetPeopleByIds {
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn execute<'life0, 'async_trait>(
+            self,
+            db: &'life0 scyllax::Executor<super::model::PersonEntity>,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<
+                        scylla::QueryResult,
+                        scylla::transport::errors::QueryError,
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<
                             scylla::QueryResult,
                             scylla::transport::errors::QueryError,
                         >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            anyhow::Result<
-                                scylla::QueryResult,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let __self = self;
-                    let __ret: anyhow::Result<
-                        scylla::QueryResult,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        let query = Self::query();
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:26",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(26u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message", "query"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
+                    > {
+                    return __ret;
+                }
+                let __self = self;
+                let __ret: Result<
+                    scylla::QueryResult,
+                    scylla::transport::errors::QueryError,
+                > = {
+                    let statement = db.queries.get::<GetPeopleByIds>();
+                    {
+                        use ::tracing::__macro_support::Callsite as _;
+                        static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                            static META: ::tracing::Metadata<'static> = {
+                                ::tracing_core::metadata::Metadata::new(
+                                    "event example/src/entities/person/queries.rs:82",
+                                    "example::entities::person::queries",
+                                    ::tracing::Level::DEBUG,
+                                    Some("example/src/entities/person/queries.rs"),
+                                    Some(82u32),
+                                    Some("example::entities::person::queries"),
+                                    ::tracing_core::field::FieldSet::new(
+                                        &["message"],
+                                        ::tracing_core::callsite::Identifier(&CALLSITE),
+                                    ),
+                                    ::tracing::metadata::Kind::EVENT,
+                                )
                             };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&format_args!("executing select") as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&query as &dyn Value),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
+                            ::tracing::callsite::DefaultCallsite::new(&META)
                         };
-                        db.session.execute(query, __self).await
+                        let enabled = ::tracing::Level::DEBUG
+                            <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                            && ::tracing::Level::DEBUG
+                                <= ::tracing::level_filters::LevelFilter::current()
+                            && {
+                                let interest = CALLSITE.interest();
+                                !interest.is_never()
+                                    && ::tracing::__macro_support::__is_enabled(
+                                        CALLSITE.metadata(),
+                                        interest,
+                                    )
+                            };
+                        if enabled {
+                            (|value_set: ::tracing::field::ValueSet| {
+                                let meta = CALLSITE.metadata();
+                                ::tracing::Event::dispatch(meta, &value_set);
+                            })({
+                                #[allow(unused_imports)]
+                                use ::tracing::field::{debug, display, Value};
+                                let mut iter = CALLSITE.metadata().fields().iter();
+                                CALLSITE
+                                    .metadata()
+                                    .fields()
+                                    .value_set(
+                                        &[
+                                            (
+                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                Some(&format_args!("executing select") as &dyn Value),
+                                            ),
+                                        ],
+                                    )
+                            });
+                        } else {
+                        }
                     };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn parse_response<'async_trait>(
-                res: scylla::QueryResult,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            Vec<super::model::PersonEntity>,
-                            scyllax::ScyllaxError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            > {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                Vec<super::model::PersonEntity>,
-                                scyllax::ScyllaxError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let res = res;
-                    let __ret: Result<
+                    db.session.execute(statement, __self).await
+                };
+                #[allow(unreachable_code)] __ret
+            })
+        }
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn parse_response<'async_trait>(
+            res: scylla::QueryResult,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<
                         Vec<super::model::PersonEntity>,
                         scyllax::ScyllaxError,
-                    > = {
-                        match res.rows_typed::<super::model::PersonEntity>() {
-                            Ok(xs) => {
-                                Ok(
-                                    xs
-                                        .filter_map(|x| x.ok())
-                                        .collect::<Vec<super::model::PersonEntity>>(),
-                                )
-                            }
-                            Err(e) => {
-                                {
-                                    use ::tracing::__macro_support::Callsite as _;
-                                    static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                        static META: ::tracing::Metadata<'static> = {
-                                            ::tracing_core::metadata::Metadata::new(
-                                                "event example/src/entities/person/queries.rs:26",
-                                                "example::entities::person::queries",
-                                                ::tracing::Level::ERROR,
-                                                Some("example/src/entities/person/queries.rs"),
-                                                Some(26u32),
-                                                Some("example::entities::person::queries"),
-                                                ::tracing_core::field::FieldSet::new(
-                                                    &["message"],
-                                                    ::tracing_core::callsite::Identifier(&CALLSITE),
-                                                ),
-                                                ::tracing::metadata::Kind::EVENT,
-                                            )
-                                        };
-                                        ::tracing::callsite::DefaultCallsite::new(&META)
-                                    };
-                                    let enabled = ::tracing::Level::ERROR
-                                        <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                        && ::tracing::Level::ERROR
-                                            <= ::tracing::level_filters::LevelFilter::current()
-                                        && {
-                                            let interest = CALLSITE.interest();
-                                            !interest.is_never()
-                                                && ::tracing::__macro_support::__is_enabled(
-                                                    CALLSITE.metadata(),
-                                                    interest,
-                                                )
-                                        };
-                                    if enabled {
-                                        (|value_set: ::tracing::field::ValueSet| {
-                                            let meta = CALLSITE.metadata();
-                                            ::tracing::Event::dispatch(meta, &value_set);
-                                        })({
-                                            #[allow(unused_imports)]
-                                            use ::tracing::field::{debug, display, Value};
-                                            let mut iter = CALLSITE.metadata().fields().iter();
-                                            CALLSITE
-                                                .metadata()
-                                                .fields()
-                                                .value_set(
-                                                    &[
-                                                        (
-                                                            &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                            Some(&format_args!("err: {0:?}", e) as &dyn Value),
-                                                        ),
-                                                    ],
-                                                )
-                                        });
-                                    } else {
-                                    }
-                                };
-                                Ok(::alloc::vec::Vec::new())
-                            }
-                        }
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-        }
-        /// Get a [`super::model::PersonEntity`] by its email address
-        pub struct GetPersonByEmail {
-            /// The email address of the [`super::model::PersonEntity`] to get
-            pub email: String,
-        }
-        impl scylla::_macro_internal::ValueList for GetPersonByEmail {
-            fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
-                let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
-                    1usize,
-                );
-                result.add_value(&self.email)?;
-                ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
-            }
-        }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for GetPersonByEmail {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field1_finish(
-                    f,
-                    "GetPersonByEmail",
-                    "email",
-                    &&self.email,
-                )
-            }
-        }
-        #[automatically_derived]
-        impl ::core::clone::Clone for GetPersonByEmail {
-            #[inline]
-            fn clone(&self) -> GetPersonByEmail {
-                GetPersonByEmail {
-                    email: ::core::clone::Clone::clone(&self.email),
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        > {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<Vec<super::model::PersonEntity>, scyllax::ScyllaxError>,
+                    > {
+                    return __ret;
                 }
-            }
-        }
-        #[automatically_derived]
-        impl ::core::marker::StructuralPartialEq for GetPersonByEmail {}
-        #[automatically_derived]
-        impl ::core::cmp::PartialEq for GetPersonByEmail {
-            #[inline]
-            fn eq(&self, other: &GetPersonByEmail) -> bool {
-                self.email == other.email
-            }
-        }
-        #[automatically_derived]
-        impl ::core::hash::Hash for GetPersonByEmail {
-            fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
-                ::core::hash::Hash::hash(&self.email, state)
-            }
-        }
-        impl scyllax::SelectQuery<
-            super::model::PersonEntity,
-            Option<super::model::PersonEntity>,
-        > for GetPersonByEmail {
-            fn query() -> String {
-                "select * from person_by_email where email = ? limit 1"
-                    .replace("*", &super::model::PersonEntity::keys().join(", "))
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn prepare<'life0, 'async_trait>(
-                db: &'life0 Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            scylla::prepared_statement::PreparedStatement,
-                            scylla::transport::errors::QueryError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                scylla::prepared_statement::PreparedStatement,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let __ret: Result<
-                        scylla::prepared_statement::PreparedStatement,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:38",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(38u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
-                            };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(
-                                                        &format_args!("preparing query {0}", "GetPersonByEmail")
-                                                            as &dyn Value,
-                                                    ),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
-                        };
-                        db.session
-                            .add_prepared_statement(
-                                &scylla::query::Query::new(Self::query()),
+                let res = res;
+                let __ret: Result<
+                    Vec<super::model::PersonEntity>,
+                    scyllax::ScyllaxError,
+                > = {
+                    match res.rows_typed::<super::model::PersonEntity>() {
+                        Ok(xs) => {
+                            Ok(
+                                xs
+                                    .filter_map(|x| x.ok())
+                                    .collect::<Vec<super::model::PersonEntity>>(),
                             )
-                            .await
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
+                        }
+                        Err(e) => {
+                            {
+                                use ::tracing::__macro_support::Callsite as _;
+                                static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                                    static META: ::tracing::Metadata<'static> = {
+                                        ::tracing_core::metadata::Metadata::new(
+                                            "event example/src/entities/person/queries.rs:82",
+                                            "example::entities::person::queries",
+                                            ::tracing::Level::ERROR,
+                                            Some("example/src/entities/person/queries.rs"),
+                                            Some(82u32),
+                                            Some("example::entities::person::queries"),
+                                            ::tracing_core::field::FieldSet::new(
+                                                &["message"],
+                                                ::tracing_core::callsite::Identifier(&CALLSITE),
+                                            ),
+                                            ::tracing::metadata::Kind::EVENT,
+                                        )
+                                    };
+                                    ::tracing::callsite::DefaultCallsite::new(&META)
+                                };
+                                let enabled = ::tracing::Level::ERROR
+                                    <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                                    && ::tracing::Level::ERROR
+                                        <= ::tracing::level_filters::LevelFilter::current()
+                                    && {
+                                        let interest = CALLSITE.interest();
+                                        !interest.is_never()
+                                            && ::tracing::__macro_support::__is_enabled(
+                                                CALLSITE.metadata(),
+                                                interest,
+                                            )
+                                    };
+                                if enabled {
+                                    (|value_set: ::tracing::field::ValueSet| {
+                                        let meta = CALLSITE.metadata();
+                                        ::tracing::Event::dispatch(meta, &value_set);
+                                    })({
+                                        #[allow(unused_imports)]
+                                        use ::tracing::field::{debug, display, Value};
+                                        let mut iter = CALLSITE.metadata().fields().iter();
+                                        CALLSITE
+                                            .metadata()
+                                            .fields()
+                                            .value_set(
+                                                &[
+                                                    (
+                                                        &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                        Some(&format_args!("err: {0:?}", e) as &dyn Value),
+                                                    ),
+                                                ],
+                                            )
+                                    });
+                                } else {
+                                }
+                            };
+                            Ok(::alloc::vec::Vec::new())
+                        }
+                    }
+                };
+                #[allow(unreachable_code)] __ret
+            })
+        }
+    }
+    /// Get a [`super::model::PersonEntity`] by its email address
+    pub struct GetPersonByEmail {
+        /// The email address of the [`super::model::PersonEntity`] to get
+        pub email: String,
+    }
+    impl scylla::_macro_internal::ValueList for GetPersonByEmail {
+        fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
+            let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
+                1usize,
+            );
+            result.add_value(&self.email)?;
+            ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
+        }
+    }
+    impl scylla::_macro_internal::FromRow for GetPersonByEmail {
+        fn from_row(
+            row: scylla::_macro_internal::Row,
+        ) -> ::std::result::Result<Self, scylla::_macro_internal::FromRowError> {
+            use scylla::_macro_internal::{CqlValue, FromCqlVal, FromRow, FromRowError};
+            use ::std::result::Result::{Ok, Err};
+            use ::std::iter::{Iterator, IntoIterator};
+            if 1usize != row.columns.len() {
+                return Err(FromRowError::WrongRowSize {
+                    expected: 1usize,
+                    actual: row.columns.len(),
+                });
             }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn execute<'life0, 'async_trait>(
-                self,
-                db: &'life0 scyllax::Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = anyhow::Result<
+            let mut vals_iter = row.columns.into_iter().enumerate();
+            Ok(GetPersonByEmail {
+                email: {
+                    let (col_ix, col_value) = vals_iter.next().unwrap();
+                    <String as FromCqlVal<
+                        ::std::option::Option<CqlValue>,
+                    >>::from_cql(col_value)
+                        .map_err(|e| FromRowError::BadCqlVal {
+                            err: e,
+                            column: col_ix,
+                        })?
+                },
+            })
+        }
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for GetPersonByEmail {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field1_finish(
+                f,
+                "GetPersonByEmail",
+                "email",
+                &&self.email,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for GetPersonByEmail {
+        #[inline]
+        fn clone(&self) -> GetPersonByEmail {
+            GetPersonByEmail {
+                email: ::core::clone::Clone::clone(&self.email),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for GetPersonByEmail {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for GetPersonByEmail {
+        #[inline]
+        fn eq(&self, other: &GetPersonByEmail) -> bool {
+            self.email == other.email
+        }
+    }
+    #[automatically_derived]
+    impl ::core::hash::Hash for GetPersonByEmail {
+        fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+            ::core::hash::Hash::hash(&self.email, state)
+        }
+    }
+    impl scyllax::GenericQuery<super::model::PersonEntity> for GetPersonByEmail {
+        fn query() -> String {
+            "select * from person_by_email where email = ? limit 1"
+                .replace("*", &super::model::PersonEntity::keys().join(", "))
+        }
+    }
+    impl scyllax::SelectQuery<
+        super::model::PersonEntity,
+        Option<super::model::PersonEntity>,
+        super::model::PersonEntity,
+    > for GetPersonByEmail {
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn execute<'life0, 'async_trait>(
+            self,
+            db: &'life0 scyllax::Executor<super::model::PersonEntity>,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<
+                        scylla::QueryResult,
+                        scylla::transport::errors::QueryError,
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<
                             scylla::QueryResult,
                             scylla::transport::errors::QueryError,
                         >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            anyhow::Result<
-                                scylla::QueryResult,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let __self = self;
-                    let __ret: anyhow::Result<
-                        scylla::QueryResult,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        let query = Self::query();
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:38",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(38u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message", "query"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
+                    > {
+                    return __ret;
+                }
+                let __self = self;
+                let __ret: Result<
+                    scylla::QueryResult,
+                    scylla::transport::errors::QueryError,
+                > = {
+                    let statement = db.queries.get::<GetPersonByEmail>();
+                    {
+                        use ::tracing::__macro_support::Callsite as _;
+                        static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                            static META: ::tracing::Metadata<'static> = {
+                                ::tracing_core::metadata::Metadata::new(
+                                    "event example/src/entities/person/queries.rs:94",
+                                    "example::entities::person::queries",
+                                    ::tracing::Level::DEBUG,
+                                    Some("example/src/entities/person/queries.rs"),
+                                    Some(94u32),
+                                    Some("example::entities::person::queries"),
+                                    ::tracing_core::field::FieldSet::new(
+                                        &["message"],
+                                        ::tracing_core::callsite::Identifier(&CALLSITE),
+                                    ),
+                                    ::tracing::metadata::Kind::EVENT,
+                                )
                             };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&format_args!("executing select") as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&query as &dyn Value),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
+                            ::tracing::callsite::DefaultCallsite::new(&META)
                         };
-                        db.session.execute(query, __self).await
+                        let enabled = ::tracing::Level::DEBUG
+                            <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                            && ::tracing::Level::DEBUG
+                                <= ::tracing::level_filters::LevelFilter::current()
+                            && {
+                                let interest = CALLSITE.interest();
+                                !interest.is_never()
+                                    && ::tracing::__macro_support::__is_enabled(
+                                        CALLSITE.metadata(),
+                                        interest,
+                                    )
+                            };
+                        if enabled {
+                            (|value_set: ::tracing::field::ValueSet| {
+                                let meta = CALLSITE.metadata();
+                                ::tracing::Event::dispatch(meta, &value_set);
+                            })({
+                                #[allow(unused_imports)]
+                                use ::tracing::field::{debug, display, Value};
+                                let mut iter = CALLSITE.metadata().fields().iter();
+                                CALLSITE
+                                    .metadata()
+                                    .fields()
+                                    .value_set(
+                                        &[
+                                            (
+                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                Some(&format_args!("executing select") as &dyn Value),
+                                            ),
+                                        ],
+                                    )
+                            });
+                        } else {
+                        }
                     };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn parse_response<'async_trait>(
-                res: scylla::QueryResult,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            Option<super::model::PersonEntity>,
-                            scyllax::ScyllaxError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            > {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                Option<super::model::PersonEntity>,
-                                scyllax::ScyllaxError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let res = res;
-                    let __ret: Result<
+                    db.session.execute(statement, __self).await
+                };
+                #[allow(unreachable_code)] __ret
+            })
+        }
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn parse_response<'async_trait>(
+            res: scylla::QueryResult,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<
                         Option<super::model::PersonEntity>,
                         scyllax::ScyllaxError,
-                    > = {
-                        match res.single_row_typed::<super::model::PersonEntity>() {
-                            Ok(data) => Ok(Some(data)),
-                            Err(err) => {
-                                use scylla::transport::query_result::SingleRowTypedError;
-                                match err {
-                                    SingleRowTypedError::BadNumberOfRows(_) => Ok(None),
-                                    _ => {
-                                        {
-                                            use ::tracing::__macro_support::Callsite as _;
-                                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                                static META: ::tracing::Metadata<'static> = {
-                                                    ::tracing_core::metadata::Metadata::new(
-                                                        "event example/src/entities/person/queries.rs:38",
-                                                        "example::entities::person::queries",
-                                                        ::tracing::Level::ERROR,
-                                                        Some("example/src/entities/person/queries.rs"),
-                                                        Some(38u32),
-                                                        Some("example::entities::person::queries"),
-                                                        ::tracing_core::field::FieldSet::new(
-                                                            &["message"],
-                                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                                        ),
-                                                        ::tracing::metadata::Kind::EVENT,
-                                                    )
-                                                };
-                                                ::tracing::callsite::DefaultCallsite::new(&META)
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        > {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        Result<Option<super::model::PersonEntity>, scyllax::ScyllaxError>,
+                    > {
+                    return __ret;
+                }
+                let res = res;
+                let __ret: Result<
+                    Option<super::model::PersonEntity>,
+                    scyllax::ScyllaxError,
+                > = {
+                    match res.single_row_typed::<super::model::PersonEntity>() {
+                        Ok(data) => Ok(Some(data)),
+                        Err(err) => {
+                            use scylla::transport::query_result::SingleRowTypedError;
+                            match err {
+                                SingleRowTypedError::BadNumberOfRows(_) => Ok(None),
+                                _ => {
+                                    {
+                                        use ::tracing::__macro_support::Callsite as _;
+                                        static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                                            static META: ::tracing::Metadata<'static> = {
+                                                ::tracing_core::metadata::Metadata::new(
+                                                    "event example/src/entities/person/queries.rs:94",
+                                                    "example::entities::person::queries",
+                                                    ::tracing::Level::ERROR,
+                                                    Some("example/src/entities/person/queries.rs"),
+                                                    Some(94u32),
+                                                    Some("example::entities::person::queries"),
+                                                    ::tracing_core::field::FieldSet::new(
+                                                        &["message"],
+                                                        ::tracing_core::callsite::Identifier(&CALLSITE),
+                                                    ),
+                                                    ::tracing::metadata::Kind::EVENT,
+                                                )
                                             };
-                                            let enabled = ::tracing::Level::ERROR
-                                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                                && ::tracing::Level::ERROR
-                                                    <= ::tracing::level_filters::LevelFilter::current()
-                                                && {
-                                                    let interest = CALLSITE.interest();
-                                                    !interest.is_never()
-                                                        && ::tracing::__macro_support::__is_enabled(
-                                                            CALLSITE.metadata(),
-                                                            interest,
-                                                        )
-                                                };
-                                            if enabled {
-                                                (|value_set: ::tracing::field::ValueSet| {
-                                                    let meta = CALLSITE.metadata();
-                                                    ::tracing::Event::dispatch(meta, &value_set);
-                                                })({
-                                                    #[allow(unused_imports)]
-                                                    use ::tracing::field::{debug, display, Value};
-                                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                                    CALLSITE
-                                                        .metadata()
-                                                        .fields()
-                                                        .value_set(
-                                                            &[
-                                                                (
-                                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                                    Some(&format_args!("err: {0:?}", err) as &dyn Value),
-                                                                ),
-                                                            ],
-                                                        )
-                                                });
-                                            } else {
-                                            }
+                                            ::tracing::callsite::DefaultCallsite::new(&META)
                                         };
-                                        Err(scyllax::ScyllaxError::SingleRowTyped(err))
-                                    }
+                                        let enabled = ::tracing::Level::ERROR
+                                            <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                                            && ::tracing::Level::ERROR
+                                                <= ::tracing::level_filters::LevelFilter::current()
+                                            && {
+                                                let interest = CALLSITE.interest();
+                                                !interest.is_never()
+                                                    && ::tracing::__macro_support::__is_enabled(
+                                                        CALLSITE.metadata(),
+                                                        interest,
+                                                    )
+                                            };
+                                        if enabled {
+                                            (|value_set: ::tracing::field::ValueSet| {
+                                                let meta = CALLSITE.metadata();
+                                                ::tracing::Event::dispatch(meta, &value_set);
+                                            })({
+                                                #[allow(unused_imports)]
+                                                use ::tracing::field::{debug, display, Value};
+                                                let mut iter = CALLSITE.metadata().fields().iter();
+                                                CALLSITE
+                                                    .metadata()
+                                                    .fields()
+                                                    .value_set(
+                                                        &[
+                                                            (
+                                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                                Some(&format_args!("err: {0:?}", err) as &dyn Value),
+                                                            ),
+                                                        ],
+                                                    )
+                                            });
+                                        } else {
+                                        }
+                                    };
+                                    Err(scyllax::ScyllaxError::SingleRowTyped(err))
                                 }
                             }
                         }
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
-        }
-        /// Get a [`super::model::PersonEntity`] by its [`uuid::Uuid`]
-        pub struct DeletePersonById {
-            /// The [`uuid::Uuid`] of the [`super::model::PersonEntity`] to get
-            pub id: Uuid,
-        }
-        impl scylla::_macro_internal::ValueList for DeletePersonById {
-            fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
-                let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
-                    1usize,
-                );
-                result.add_value(&self.id)?;
-                ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
-            }
-        }
-        #[automatically_derived]
-        impl ::core::fmt::Debug for DeletePersonById {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                ::core::fmt::Formatter::debug_struct_field1_finish(
-                    f,
-                    "DeletePersonById",
-                    "id",
-                    &&self.id,
-                )
-            }
-        }
-        #[automatically_derived]
-        impl ::core::clone::Clone for DeletePersonById {
-            #[inline]
-            fn clone(&self) -> DeletePersonById {
-                DeletePersonById {
-                    id: ::core::clone::Clone::clone(&self.id),
-                }
-            }
-        }
-        #[automatically_derived]
-        impl ::core::marker::StructuralPartialEq for DeletePersonById {}
-        #[automatically_derived]
-        impl ::core::cmp::PartialEq for DeletePersonById {
-            #[inline]
-            fn eq(&self, other: &DeletePersonById) -> bool {
-                self.id == other.id
-            }
-        }
-        #[automatically_derived]
-        impl ::core::hash::Hash for DeletePersonById {
-            fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
-                ::core::hash::Hash::hash(&self.id, state)
-            }
-        }
-        impl scyllax::DeleteQuery<super::model::PersonEntity> for DeletePersonById {
-            fn query() -> String {
-                "delete from person where id = ?".to_string()
-            }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn prepare<'life0, 'async_trait>(
-                db: &'life0 Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = Result<
-                            scylla::prepared_statement::PreparedStatement,
-                            scylla::transport::errors::QueryError,
-                        >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            Result<
-                                scylla::prepared_statement::PreparedStatement,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
                     }
-                    let __ret: Result<
-                        scylla::prepared_statement::PreparedStatement,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        let query = Self::query();
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:48",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(48u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message", "target", "query"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
-                            };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&format_args!("preparing query") as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&"DeletePersonById" as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&query as &dyn Value),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
-                        };
-                        db.session
-                            .add_prepared_statement(&scylla::query::Query::new(query))
-                            .await
-                    };
-                    #[allow(unreachable_code)] __ret
-                })
+                };
+                #[allow(unreachable_code)] __ret
+            })
+        }
+    }
+    /// Get a [`super::model::PersonEntity`] by its [`uuid::Uuid`]
+    pub struct DeletePersonById {
+        /// The [`uuid::Uuid`] of the [`super::model::PersonEntity`] to get
+        pub id: Uuid,
+    }
+    impl scylla::_macro_internal::ValueList for DeletePersonById {
+        fn serialized(&self) -> scylla::_macro_internal::SerializedResult {
+            let mut result = scylla::_macro_internal::SerializedValues::with_capacity(
+                1usize,
+            );
+            result.add_value(&self.id)?;
+            ::std::result::Result::Ok(::std::borrow::Cow::Owned(result))
+        }
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for DeletePersonById {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            ::core::fmt::Formatter::debug_struct_field1_finish(
+                f,
+                "DeletePersonById",
+                "id",
+                &&self.id,
+            )
+        }
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for DeletePersonById {
+        #[inline]
+        fn clone(&self) -> DeletePersonById {
+            DeletePersonById {
+                id: ::core::clone::Clone::clone(&self.id),
             }
-            #[allow(
-                clippy::async_yields_async,
-                clippy::diverging_sub_expression,
-                clippy::let_unit_value,
-                clippy::no_effect_underscore_binding,
-                clippy::shadow_same,
-                clippy::type_complexity,
-                clippy::type_repetition_in_bounds,
-                clippy::used_underscore_binding
-            )]
-            fn execute<'life0, 'async_trait>(
-                self,
-                db: &'life0 scyllax::Executor,
-            ) -> ::core::pin::Pin<
-                Box<
-                    dyn ::core::future::Future<
-                        Output = anyhow::Result<
+        }
+    }
+    #[automatically_derived]
+    impl ::core::marker::StructuralPartialEq for DeletePersonById {}
+    #[automatically_derived]
+    impl ::core::cmp::PartialEq for DeletePersonById {
+        #[inline]
+        fn eq(&self, other: &DeletePersonById) -> bool {
+            self.id == other.id
+        }
+    }
+    #[automatically_derived]
+    impl ::core::hash::Hash for DeletePersonById {
+        fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+            ::core::hash::Hash::hash(&self.id, state)
+        }
+    }
+    impl scyllax::GenericQuery<super::model::PersonEntity> for DeletePersonById {
+        fn query() -> String {
+            "delete from person where id = ?".to_string()
+        }
+    }
+    impl scyllax::DeleteQuery<super::model::PersonEntity, "# inner_entity_typeQueries">
+    for DeletePersonById {
+        #[allow(
+            clippy::async_yields_async,
+            clippy::diverging_sub_expression,
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn execute<'life0, 'async_trait>(
+            self,
+            db: &'life0 scyllax::Executor<"# inner_entity_typeQueries">,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = anyhow::Result<
+                        scylla::QueryResult,
+                        scylla::transport::errors::QueryError,
+                    >,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+        {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret)
+                    = ::core::option::Option::None::<
+                        anyhow::Result<
                             scylla::QueryResult,
                             scylla::transport::errors::QueryError,
                         >,
-                    > + ::core::marker::Send + 'async_trait,
-                >,
-            >
-            where
-                'life0: 'async_trait,
-                Self: 'async_trait,
-            {
-                Box::pin(async move {
-                    if let ::core::option::Option::Some(__ret)
-                        = ::core::option::Option::None::<
-                            anyhow::Result<
-                                scylla::QueryResult,
-                                scylla::transport::errors::QueryError,
-                            >,
-                        > {
-                        return __ret;
-                    }
-                    let __self = self;
-                    let __ret: anyhow::Result<
-                        scylla::QueryResult,
-                        scylla::transport::errors::QueryError,
-                    > = {
-                        let query = Self::query();
-                        {
-                            use ::tracing::__macro_support::Callsite as _;
-                            static CALLSITE: ::tracing::callsite::DefaultCallsite = {
-                                static META: ::tracing::Metadata<'static> = {
-                                    ::tracing_core::metadata::Metadata::new(
-                                        "event example/src/entities/person/queries.rs:48",
-                                        "example::entities::person::queries",
-                                        ::tracing::Level::DEBUG,
-                                        Some("example/src/entities/person/queries.rs"),
-                                        Some(48u32),
-                                        Some("example::entities::person::queries"),
-                                        ::tracing_core::field::FieldSet::new(
-                                            &["message", "query"],
-                                            ::tracing_core::callsite::Identifier(&CALLSITE),
-                                        ),
-                                        ::tracing::metadata::Kind::EVENT,
-                                    )
-                                };
-                                ::tracing::callsite::DefaultCallsite::new(&META)
+                    > {
+                    return __ret;
+                }
+                let __self = self;
+                let __ret: anyhow::Result<
+                    scylla::QueryResult,
+                    scylla::transport::errors::QueryError,
+                > = {
+                    let query = Self::query();
+                    {
+                        use ::tracing::__macro_support::Callsite as _;
+                        static CALLSITE: ::tracing::callsite::DefaultCallsite = {
+                            static META: ::tracing::Metadata<'static> = {
+                                ::tracing_core::metadata::Metadata::new(
+                                    "event example/src/entities/person/queries.rs:104",
+                                    "example::entities::person::queries",
+                                    ::tracing::Level::DEBUG,
+                                    Some("example/src/entities/person/queries.rs"),
+                                    Some(104u32),
+                                    Some("example::entities::person::queries"),
+                                    ::tracing_core::field::FieldSet::new(
+                                        &["message", "query"],
+                                        ::tracing_core::callsite::Identifier(&CALLSITE),
+                                    ),
+                                    ::tracing::metadata::Kind::EVENT,
+                                )
                             };
-                            let enabled = ::tracing::Level::DEBUG
-                                <= ::tracing::level_filters::STATIC_MAX_LEVEL
-                                && ::tracing::Level::DEBUG
-                                    <= ::tracing::level_filters::LevelFilter::current()
-                                && {
-                                    let interest = CALLSITE.interest();
-                                    !interest.is_never()
-                                        && ::tracing::__macro_support::__is_enabled(
-                                            CALLSITE.metadata(),
-                                            interest,
-                                        )
-                                };
-                            if enabled {
-                                (|value_set: ::tracing::field::ValueSet| {
-                                    let meta = CALLSITE.metadata();
-                                    ::tracing::Event::dispatch(meta, &value_set);
-                                })({
-                                    #[allow(unused_imports)]
-                                    use ::tracing::field::{debug, display, Value};
-                                    let mut iter = CALLSITE.metadata().fields().iter();
-                                    CALLSITE
-                                        .metadata()
-                                        .fields()
-                                        .value_set(
-                                            &[
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&format_args!("executing delete") as &dyn Value),
-                                                ),
-                                                (
-                                                    &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                                                    Some(&query as &dyn Value),
-                                                ),
-                                            ],
-                                        )
-                                });
-                            } else {
-                            }
+                            ::tracing::callsite::DefaultCallsite::new(&META)
                         };
-                        db.session.execute(query, __self).await
+                        let enabled = ::tracing::Level::DEBUG
+                            <= ::tracing::level_filters::STATIC_MAX_LEVEL
+                            && ::tracing::Level::DEBUG
+                                <= ::tracing::level_filters::LevelFilter::current()
+                            && {
+                                let interest = CALLSITE.interest();
+                                !interest.is_never()
+                                    && ::tracing::__macro_support::__is_enabled(
+                                        CALLSITE.metadata(),
+                                        interest,
+                                    )
+                            };
+                        if enabled {
+                            (|value_set: ::tracing::field::ValueSet| {
+                                let meta = CALLSITE.metadata();
+                                ::tracing::Event::dispatch(meta, &value_set);
+                            })({
+                                #[allow(unused_imports)]
+                                use ::tracing::field::{debug, display, Value};
+                                let mut iter = CALLSITE.metadata().fields().iter();
+                                CALLSITE
+                                    .metadata()
+                                    .fields()
+                                    .value_set(
+                                        &[
+                                            (
+                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                Some(&format_args!("executing delete") as &dyn Value),
+                                            ),
+                                            (
+                                                &iter.next().expect("FieldSet corrupted (this is a bug)"),
+                                                Some(&query as &dyn Value),
+                                            ),
+                                        ],
+                                    )
+                            });
+                        } else {
+                        }
                     };
-                    #[allow(unreachable_code)] __ret
-                })
-            }
+                    db.session.execute(query, __self).await
+                };
+                #[allow(unreachable_code)] __ret
+            })
         }
     }
 }

--- a/example/src/entities/person/model.rs
+++ b/example/src/entities/person/model.rs
@@ -1,3 +1,4 @@
+use super::queries::PersonQueries;
 use scyllax::prelude::*;
 
 /// Represents data from a person
@@ -10,7 +11,7 @@ pub struct PersonData {
 
 /// Represents a person in the database
 #[entity]
-#[upsert_query(table = "person", name = UpsertPerson)]
+// #[upsert_query(table = "person", name = UpsertPerson, query_cache = PersonQueries)]
 pub struct PersonEntity {
     /// The id of the person
     #[pk]

--- a/example/src/entities/person/queries.rs
+++ b/example/src/entities/person/queries.rs
@@ -1,18 +1,20 @@
+use scyllax::PreparedStatement;
+#[allow(non_snake_case)]
 use scyllax::{delete_query, prelude::*};
 use uuid::Uuid;
 
-/// Load all queries for this entity
-#[tracing::instrument(skip(db))]
-pub async fn load(db: &mut Executor) -> anyhow::Result<()> {
-    let _ = GetPersonById::prepare(db).await;
-    let _ = GetPeopleByIds::prepare(db).await;
-    let _ = GetPersonByEmail::prepare(db).await;
-    let _ = DeletePersonById::prepare(db).await;
-
-    Ok(())
-}
+prepare_queries!(
+    PersonEntityQueries,
+    [
+        GetPersonById,
+        GetPeopleByIds,
+        GetPersonByEmail,
+        // DeletePersonById
+    ]
+);
 
 /// Get a [`super::model::PersonEntity`] by its [`uuid::Uuid`]
+// #[derive(scylla::ValueList, std::fmt::Debug, std::clone::Clone, PartialEq, Hash)]
 #[select_query(
     query = "select * from person where id = ? limit 1",
     entity_type = "super::model::PersonEntity"
@@ -21,6 +23,59 @@ pub struct GetPersonById {
     /// The [`uuid::Uuid`] of the [`super::model::PersonEntity`] to get
     pub id: Uuid,
 }
+
+// impl scyllax::GenericQuery<PersonEntity> for GetPersonById {
+//     fn query() -> String {
+//         "select * from person where id = ? limit 1"
+//             .replace("*", &PersonEntity::keys().join(", "))
+//     }
+// }
+
+// #[scyllax::async_trait]
+// impl scyllax::SelectQuery<PersonEntity, PersonEntity, PersonQueries> for GetPersonById {
+//     async fn execute(self, db: &scyllax::Executor<PersonQueries>) -> anyhow::Result<scylla::QueryResult, scylla::transport::errors::QueryError> {
+//         let statement = db.queries.get::<GetPersonById>();
+//         tracing::debug!{
+//             target = "GetPersonById",
+//             "executing select"
+//         };
+
+//         db.session.execute(statement, self).await
+//     }
+
+//     async fn parse_response(res: scylla::QueryResult) -> Result<GetPersonById, scyllax::ScyllaxError> {
+//         todo!()
+//     }
+// }
+
+// pub struct PersonQueries {
+//     GetPersonById: PreparedStatement,
+// }
+
+// #[scyllax::async_trait]
+// #[doc = "A collection of prepared statements."]
+// impl scyllax::Queries for PersonQueries {
+//     async fn new(session: &scylla::Session) -> Result<Self, scyllax::ScyllaxError> {
+//         Ok(Self {
+//             GetPersonById: session.prepare(GetPersonById::query()).await?,
+//         })
+//     }
+
+//     #[doc = "Get a prepared statement."]
+//     fn get<T>(&self) -> &scylla::statement::prepared_statement::PreparedStatement
+//     where
+//         Self: scyllax::GetPreparedStatement<T>,
+//     {
+//         <Self as scyllax::GetPreparedStatement<T>>::get_prepared_statement(self)
+//     }
+// }
+
+// impl scyllax::GetPreparedStatement<GetPersonById> for PersonQueries {
+//     #[doc = "Get a prepared statement."]
+//     fn get_prepared_statement(&self) -> &scylla::statement::prepared_statement::PreparedStatement {
+//         &self.GetPersonById
+//     }
+// }
 
 /// Get many [`super::model::PersonEntity`] by many [`uuid::Uuid`]
 #[select_query(
@@ -53,6 +108,20 @@ pub struct DeletePersonById {
     /// The [`uuid::Uuid`] of the [`super::model::PersonEntity`] to get
     pub id: Uuid,
 }
+
+// fn test() {
+//     use scylla::batch::*;
+
+//     let batch = Batch::new_with_statements(
+//         BatchType::Logged,
+//         vec![
+//             BatchStatement::Query(GenericQuery::<GetPersonById>::query()),
+//             BatchStatement::Query(GenericQuery::<GetPeopleByIds>::query()),
+//             BatchStatement::Query(GenericQuery::<GetPersonByEmail>::query()),
+//             BatchStatement::Query(GenericQuery::<DeletePersonById>::query()),
+//         ]
+//     );
+// }
 
 #[cfg(test)]
 mod test {

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,7 +1,9 @@
 //! Example
 use entities::person::{
     model::{PersonData, UpsertPerson},
-    queries::{load, DeletePersonById, GetPeopleByIds, GetPersonByEmail, GetPersonById},
+    queries::{
+        DeletePersonById, GetPeopleByIds, GetPersonByEmail, GetPersonById, PersonEntityQueries,
+    },
 };
 use scyllax::prelude::*;
 use scyllax::{executor::create_session, util::v1_uuid};
@@ -22,9 +24,9 @@ async fn main() -> anyhow::Result<()> {
     let default_keyspace = std::env::var("SCYLLA_DEFAULT_KEYSPACE").ok();
 
     let session = create_session(known_nodes, default_keyspace).await?;
-    let mut executor = Executor::with_session(session);
+    let queries = PersonEntityQueries::new(&session).await?;
 
-    load(&mut executor).await?;
+    let mut executor = Executor::with_session(session, queries);
 
     let query = GetPersonByEmail {
         email: "foo1@scyllax.local".to_string(),

--- a/scyllax-macros-core/Cargo.toml
+++ b/scyllax-macros-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "scyllax-macros-core"
+description = "Core macros for scyllax"
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+readme = "../README.md"
+
+[dependencies]
+anyhow = { workspace = true }
+darling = { version = "0.20", features = ["suggestions"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "derive", "extra-traits"] }

--- a/scyllax-macros-core/src/entity.rs
+++ b/scyllax-macros-core/src/entity.rs
@@ -1,11 +1,11 @@
+//! Entity derive macro.
 use crate::token_stream_with_error;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Expr, Field, ItemStruct};
 
-/// Attribute expand
-/// Just adds the dervie macro to the struct.
-pub(crate) fn expand(input: TokenStream) -> TokenStream {
+/// Expand the `Entity` derive macro.
+pub fn expand(input: TokenStream) -> TokenStream {
     let input: ItemStruct = match syn::parse2(input.clone()) {
         Ok(it) => it,
         Err(e) => return token_stream_with_error(input, e),
@@ -55,7 +55,7 @@ fn entity_impl(input: &ItemStruct, pks: &[&Field]) -> TokenStream {
 ///
 /// Rename is usually used to support camelCase keys, which need to be wrapped
 /// in quotes or scylla will snake_ify it.
-pub(crate) fn get_field_name(field: &Field) -> String {
+pub fn get_field_name(field: &Field) -> String {
     let rename = field.attrs.iter().find(|a| a.path().is_ident("rename"));
     if let Some(rename) = rename {
         let expr = rename.parse_args::<Expr>().expect("Expected an expression");
@@ -73,7 +73,8 @@ pub(crate) fn get_field_name(field: &Field) -> String {
         .to_string()
 }
 
-pub(crate) fn expand_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
+/// Expand the `Entity` attr macro.
+pub fn expand_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
     quote! {
         #[derive(Clone, Debug, PartialEq, scyllax::FromRow, scyllax::prelude::ValueList, scyllax::Entity)]
         #input

--- a/scyllax-macros-core/src/json.rs
+++ b/scyllax-macros-core/src/json.rs
@@ -1,16 +1,19 @@
+//! Macros for working with JSON data.
 use crate::token_stream_with_error;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::ItemStruct;
 
-pub(crate) fn expand_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
+/// Expand the `JsonData` attr macro.
+pub fn expand_attr(_args: TokenStream, input: TokenStream) -> TokenStream {
     quote! {
         #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, scyllax::prelude::JsonData)]
         #input
     }
 }
 
-pub(crate) fn expand(input: TokenStream) -> TokenStream {
+/// Expand the `JsonData` derive macro.
+pub fn expand(input: TokenStream) -> TokenStream {
     let input: ItemStruct = match syn::parse2(input.clone()) {
         Ok(it) => it,
         Err(e) => return token_stream_with_error(input, e),

--- a/scyllax-macros-core/src/lib.rs
+++ b/scyllax-macros-core/src/lib.rs
@@ -1,0 +1,17 @@
+//! Scyllax macros. See the scyllax for more information.
+use proc_macro2::TokenStream;
+
+pub mod entity;
+pub mod json;
+pub mod queries;
+
+/// Throw an error with the tokens for better error messages.
+pub fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {
+    tokens.extend(error.into_compile_error());
+    tokens
+}
+
+/// Expand the `prepare_queries!` macro.
+pub fn prepare_queries(input: TokenStream) -> TokenStream {
+    queries::prepare::expand(input)
+}

--- a/scyllax-macros-core/src/queries/delete.rs
+++ b/scyllax-macros-core/src/queries/delete.rs
@@ -1,3 +1,4 @@
+//! Macros for delete queries.
 use darling::{export::NestedMeta, FromMeta};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -5,19 +6,23 @@ use syn::ItemStruct;
 
 use crate::token_stream_with_error;
 
+/// Options for the `#[delete_query]` attribute macro.
 #[derive(FromMeta)]
-pub(crate) struct SelectQueryOptions {
-    query: String,
-    entity_type: syn::Type,
+pub struct DeleteQueryOptions {
+    /// The query to execute.
+    pub query: String,
+    /// The type of the entity to return.
+    pub entity_type: syn::Type,
 }
 
-pub(crate) fn expand(args: TokenStream, item: TokenStream) -> TokenStream {
+/// Expand the `#[delete_query]` attribute macro.
+pub fn expand(args: TokenStream, item: TokenStream) -> TokenStream {
     let attr_args = match NestedMeta::parse_meta_list(args.clone()) {
         Ok(args) => args,
         Err(e) => return darling::Error::from(e).write_errors(),
     };
 
-    let args = match SelectQueryOptions::from_list(&attr_args) {
+    let args = match DeleteQueryOptions::from_list(&attr_args) {
         Ok(o) => o,
         Err(e) => return e.write_errors(),
     };
@@ -30,28 +35,21 @@ pub(crate) fn expand(args: TokenStream, item: TokenStream) -> TokenStream {
         Err(e) => return token_stream_with_error(item, e),
     };
     let struct_ident = &input.ident;
+    let query_cache = concat!(stringify!(#inner_entity_type), "Queries");
 
     quote! {
         #[derive(scylla::ValueList, std::fmt::Debug, std::clone::Clone, PartialEq, Hash)]
         #input
 
-        #[scyllax::async_trait]
-        impl scyllax::DeleteQuery<#entity_type> for #struct_ident {
+        impl scyllax::GenericQuery<#entity_type> for #struct_ident {
             fn query() -> String {
                 #query.to_string()
             }
+        }
 
-            async fn prepare(db: &Executor) -> Result<scylla::prepared_statement::PreparedStatement, scylla::transport::errors::QueryError> {
-                let query = Self::query();
-                tracing::debug!{
-                    target = stringify!(#struct_ident),
-                    query,
-                    "preparing query"
-                };
-                db.session.add_prepared_statement(&scylla::query::Query::new(query)).await
-            }
-
-            async fn execute(self, db: &scyllax::Executor) -> anyhow::Result<scylla::QueryResult, scylla::transport::errors::QueryError> {
+        #[scyllax::async_trait]
+        impl scyllax::DeleteQuery<#entity_type, #query_cache> for #struct_ident {
+            async fn execute(self, db: &scyllax::Executor<#query_cache>) -> anyhow::Result<scylla::QueryResult, scylla::transport::errors::QueryError> {
                 let query = Self::query();
                 tracing::debug! {
                     query,

--- a/scyllax-macros-core/src/queries/mod.rs
+++ b/scyllax-macros-core/src/queries/mod.rs
@@ -1,0 +1,5 @@
+//! Mostly `expand` functions for the macros.
+pub mod delete;
+pub mod prepare;
+pub mod select;
+pub mod upsert;

--- a/scyllax-macros-core/src/queries/prepare.rs
+++ b/scyllax-macros-core/src/queries/prepare.rs
@@ -1,0 +1,110 @@
+//! This module contains the `prepare_queries!` macro.
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    ExprArray,
+};
+
+// // prepare_queries!(PersonQueries, [GetPersonById, GetPeopleByIds, DeletePersonById, ...]);
+/// Options for the `prepare_queries!` macro.
+pub struct PrepareQueriesInput {
+    /// The name of the struct to generate.
+    pub name: syn::Ident,
+    /// The queries to attach to the struct.
+    pub queries: Vec<syn::Ident>,
+}
+
+impl Parse for PrepareQueriesInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let name = input.parse()?;
+        input.parse::<syn::Token![,]>()?;
+
+        let queries = input
+            .parse::<ExprArray>()?
+            .elems
+            .iter()
+            .map(|expr| {
+                if let syn::Expr::Path(path) = expr {
+                    Ok(path.path.get_ident().unwrap().clone())
+                } else {
+                    Err(syn::Error::new_spanned(expr, "expected an identifier"))
+                }
+            })
+            .collect::<syn::Result<Vec<_>>>()?;
+
+        Ok(Self { name, queries })
+    }
+}
+
+// prepare_queries!(PersonQueries, [GetPersonById, GetPeopleByIds, DeletePersonById, ...]);
+// creates a struct like this:
+// pub struct PersonQueries {
+//   GetPersonById: scylla::statement::prepared_statement::PreparedStatement,
+//   GetPeopleByIds: scylla::statement::prepared_statement::PreparedStatement,
+//   DeletePersonById: scylla::statement::prepared_statement::PreparedStatement,
+//   ...
+// }
+/// Expands the `prepare_queries!` macro.
+pub fn expand(input: TokenStream) -> TokenStream {
+    let args: PrepareQueriesInput = match syn::parse2(input) {
+        Ok(args) => args,
+        Err(e) => return e.to_compile_error(),
+    };
+    let queries = args.queries;
+    let name = args.name;
+
+    let stmts = queries.iter().map(|field| {
+        let doc = format!("The prepared statement for `{}`.", field);
+        quote! {
+            #[allow(non_snake_case)]
+            #[doc = #doc]
+            pub #field: scylla::statement::prepared_statement::PreparedStatement,
+        }
+    });
+
+    let gets = queries.iter().map(|field| {
+		quote! {
+			impl scyllax::GetPreparedStatement<#field> for #name {
+				#[doc = "Get a prepared statement."]
+				fn get_prepared_statement(&self) -> &scylla::statement::prepared_statement::PreparedStatement {
+					&self.#field
+				}
+			}
+		}
+	});
+
+    let prepares = queries.iter().map(|field| {
+        quote! {
+            #field: session.prepare(#field::query()).await?,
+        }
+    });
+
+    quote! {
+        #[doc = "A collection of prepared statements."]
+        #[allow(non_snake_case)]
+        pub struct #name {
+            #(#stmts)*
+        }
+
+        #[scyllax::async_trait]
+        #[doc = "A collection of prepared statements."]
+        impl scyllax::Queries for #name {
+            async fn new(session: &scylla::Session) -> Result<Self, scyllax::ScyllaxError> {
+                Ok(Self {
+                    #(#prepares)*
+                })
+            }
+
+            #[doc = "Get a prepared statement."]
+            fn get<T>(&self) -> &scylla::statement::prepared_statement::PreparedStatement
+            where
+                Self: scyllax::GetPreparedStatement<T>,
+            {
+                <Self as scyllax::GetPreparedStatement<T>>::get_prepared_statement(self)
+            }
+        }
+
+        #(#gets)*
+    }
+}

--- a/scyllax-macros/Cargo.toml
+++ b/scyllax-macros/Cargo.toml
@@ -13,8 +13,4 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-anyhow = { workspace = true }
-darling = { version = "0.20", features = ["suggestions"] }
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full", "derive", "extra-traits"] }
+scyllax-macros-core = { version = "0.1.4-alpha", path = "../scyllax-macros-core" }

--- a/scyllax-macros/src/lib.rs
+++ b/scyllax-macros/src/lib.rs
@@ -1,15 +1,6 @@
 //! Scyllax macros. See the scyllax for more information.
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
-
-mod entity;
-mod json;
-mod queries;
-
-pub(crate) fn token_stream_with_error(mut tokens: TokenStream2, error: syn::Error) -> TokenStream2 {
-    tokens.extend(error.into_compile_error());
-    tokens
-}
+use scyllax_macros_core::*;
 
 /// Apply this attribute to a struct to generate a select query.
 /// ## Single result
@@ -106,4 +97,10 @@ pub fn json_derive(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn json_data(args: TokenStream, input: TokenStream) -> TokenStream {
     json::expand_attr(args.into(), input.into()).into()
+}
+
+/// Create a superstruct of all queries.
+#[proc_macro]
+pub fn prepare_queries(input: TokenStream) -> TokenStream {
+    queries::prepare::expand(input.into()).into()
 }

--- a/scyllax-macros/src/queries/mod.rs
+++ b/scyllax-macros/src/queries/mod.rs
@@ -1,3 +1,0 @@
-pub mod delete;
-pub mod select;
-pub mod upsert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,16 +69,11 @@ pub trait EntityExt<T: ImplValueList + FromRow> {
 pub trait SelectQuery<
     T: EntityExt<T> + ImplValueList + FromRow,
     R: Clone + std::fmt::Debug + Send + Sync,
+    Q: Queries,
 >
 {
-    /// Returns the query as a string
-    fn query() -> String;
-
-    /// Prepares the query
-    async fn prepare(db: &Executor) -> Result<PreparedStatement, QueryError>;
-
     /// Executes the query
-    async fn execute(self, db: &Executor) -> Result<QueryResult, QueryError>;
+    async fn execute(self, db: &Executor<Q>) -> Result<QueryResult, QueryError>;
 
     /// Parses the response from the database
     async fn parse_response(res: QueryResult) -> Result<R, ScyllaxError>;
@@ -86,27 +81,51 @@ pub trait SelectQuery<
 
 /// The trait that's implemented on update/insert queryes
 #[async_trait]
-pub trait UpsertQuery<T: EntityExt<T> + ImplValueList + FromRow> {
+pub trait UpsertQuery<T: EntityExt<T> + ImplValueList + FromRow, Q: Queries> {
     /// Returns the query as a string
-    fn query(
+    fn create_serialized_values(
         &self,
-    ) -> Result<(String, scylla::frame::value::SerializedValues), BuildUpsertQueryError>;
+    ) -> Result<scylla::frame::value::SerializedValues, BuildUpsertQueryError>;
 
     /// Executes the query
-    async fn execute(self, db: &Executor) -> Result<QueryResult, ScyllaxError>;
+    async fn execute(self, db: &Executor<Q>) -> Result<QueryResult, ScyllaxError>;
 }
 
 /// The trait that's implemented on delete queries
 // R is the return type of the query
 // It can be either Option<T> or Vec<T>
 #[async_trait]
-pub trait DeleteQuery<T: EntityExt<T> + ImplValueList + FromRow> {
+pub trait DeleteQuery<T: EntityExt<T> + ImplValueList + FromRow, Q: Queries> {
+    /// Executes the query
+    async fn execute(self, db: &Executor<Q>) -> Result<QueryResult, QueryError>;
+}
+
+/// Applied to a superstruct of prepared statements.
+pub trait GetPreparedStatement<T> {
+    /// Returns the prepared statement
+    fn get_prepared_statement(&self) -> &PreparedStatement;
+}
+
+/// A generic query that implements `query`.
+pub trait GenericQuery<T: EntityExt<T> + ImplValueList + FromRow> {
     /// Returns the query as a string
     fn query() -> String;
+}
 
-    /// Prepares the query
-    async fn prepare(db: &Executor) -> Result<PreparedStatement, QueryError>;
+/// A superstruct of all the queries
+#[async_trait]
+pub trait Queries
+where
+    Self: Sized,
+{
+    /// Creates a new instance
+    async fn new(session: &scylla::Session) -> Result<Self, ScyllaxError>;
 
-    /// Executes the query
-    async fn execute(self, db: &Executor) -> Result<QueryResult, QueryError>;
+    #[doc = "Get a prepared statement."]
+    fn get<T>(&self) -> &scylla::statement::prepared_statement::PreparedStatement
+    where
+        Self: GetPreparedStatement<T>,
+    {
+        <Self as GetPreparedStatement<T>>::get_prepared_statement(self)
+    }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,9 @@
 //! Re-exports of the most commonly used types and traits.
 pub use crate::{
     delete_query, entity, error::BuildUpsertQueryError, executor::Executor, json_data,
-    maybe_unset::MaybeUnset, select_query, upsert_query, util::v1_uuid, DeleteQuery, Entity,
-    EntityExt, FromRow, ImplValueList, JsonData, ScyllaxError, SelectQuery, UpsertQuery,
+    maybe_unset::MaybeUnset, prepare_queries, select_query, upsert_query, util::v1_uuid,
+    DeleteQuery, Entity, EntityExt, FromRow, GenericQuery, GetPreparedStatement, ImplValueList,
+    JsonData, Queries, ScyllaxError, SelectQuery, UpsertQuery,
 };
 
 pub use scylla::frame::value::SerializeValuesError;


### PR DESCRIPTION
This PR refactors a lot of code to support prepared queries.

I can already hear you.
"*But @Fyko, [`scylla::CachingSession`](https://docs.rs/scylla/latest/scylla/struct.CachingSession.html) already uses prepared queries and even caches them for you!*".

Yes, it does. But every time we perform a query, we have to do a hash and lookup. Which is signifigantly slower than just reading a property.
We're already using a shitton of macros, why not just write another?

Shoutout jake for making my lose sleep at night. 😅